### PR TITLE
Remove symengine dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ crosstalk-pass = [
 csp-layout-pass = [
     "python-constraint >= 1.4",
 ]
+tests = [
+    "ddt>=1.2.0,!=1.4.0,!=1.4.3",
+]
 # This will make the resolution work for installers from PyPI, but `pip install .[all]` will be
 # unreliable because `qiskit` will resolve to the PyPI version, so local changes in the
 # optionals won't be reflected.

--- a/qiskit/circuit/parameter.py
+++ b/qiskit/circuit/parameter.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from uuid import uuid4, UUID
 
-import symengine
+import sympy as symengine
 
 from qiskit.circuit.exceptions import CircuitError
 

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -23,7 +23,7 @@ import numbers
 import operator
 
 import numpy
-import symengine
+import sympy as symengine
 
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.exceptions import QiskitError

--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -49,7 +49,7 @@ def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
     if isinstance(inpt, ParameterExpression):
         param_str = str(inpt)
         from sympy import sympify
-        import symengine
+        import sympy as symengine
 
         if not isinstance(inpt._symbol_expr, symengine.Basic):
             raise QiskitError("Invalid ParameterExpression provided")

--- a/qiskit/qpy/binary_io/schedules.py
+++ b/qiskit/qpy/binary_io/schedules.py
@@ -23,7 +23,7 @@ import zlib
 from io import BytesIO
 
 import numpy as np
-import symengine as sym
+import sympy as sym
 
 from qiskit.exceptions import QiskitError
 from qiskit.qpy import formats, common, type_keys
@@ -91,14 +91,11 @@ def _loads_symbolic_expr(expr_bytes, use_symengine=False):
     if expr_bytes == b"":
         return None
     expr_bytes = zlib.decompress(expr_bytes)
-    if use_symengine:
-        return common.load_symengine_payload(expr_bytes)
-    else:
-        from sympy import parse_expr
+    from sympy import parse_expr
 
-        expr_txt = expr_bytes.decode(common.ENCODE)
-        expr = parse_expr(expr_txt)
-        return sym.sympify(expr)
+    expr_txt = expr_bytes.decode(common.ENCODE)
+    expr = parse_expr(expr_txt)
+    return sym.sympify(expr)
 
 
 def _read_symbolic_pulse(file_obj, version) -> None:
@@ -159,10 +156,10 @@ def _read_symbolic_pulse_v6(file_obj, version, use_symengine) -> None:
     )
     class_name = file_obj.read(header.class_name_size).decode(common.ENCODE)
     file_obj.read(header.type_size).decode(common.ENCODE)  # read pulse type
-    _loads_symbolic_expr(file_obj.read(header.envelope_size), use_symengine)  # read envelope
-    _loads_symbolic_expr(file_obj.read(header.constraints_size), use_symengine)  # read constraints
+    _loads_symbolic_expr(file_obj.read(header.envelope_size))  # read envelope
+    _loads_symbolic_expr(file_obj.read(header.constraints_size))  # read constraints
     _loads_symbolic_expr(
-        file_obj.read(header.valid_amp_conditions_size), use_symengine
+        file_obj.read(header.valid_amp_conditions_size)
     )  # read valid_amp_conditions
     # read parameters
     common.read_mapping(

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -20,7 +20,7 @@ import struct
 import uuid
 
 import numpy as np
-import symengine
+import sympy as symengine
 
 
 from qiskit.circuit import CASE_DEFAULT, Clbit, ClassicalRegister, Duration
@@ -512,11 +512,8 @@ def _read_parameter_expression_v3(file_obj, vectors, use_symengine):
     )
 
     payload = file_obj.read(data.expr_size)
-    if use_symengine:
-        expr_ = common.load_symengine_payload(payload)
-    else:
-        sympy_str = payload.decode(common.ENCODE)
-        expr_ = symengine.sympify(parse_sympy_repr(sympy_str))
+    sympy_str = payload.decode(common.ENCODE)
+    expr_ = symengine.sympify(parse_sympy_repr(sympy_str))
 
     symbol_map = {}
     for _ in range(data.map_elements):

--- a/qiskit/qpy/common.py
+++ b/qiskit/qpy/common.py
@@ -18,7 +18,6 @@ Common functions across several serialization and deserialization modules.
 import io
 import struct
 
-from qiskit.utils.optionals import HAS_SYMENGINE
 
 from qiskit.qpy import formats, exceptions
 
@@ -308,46 +307,6 @@ def mapping_from_binary(binary_data, deserializer, **kwargs):
     return mapping
 
 
-@HAS_SYMENGINE.require_in_call("QPY versions 10 through 12 with symengine parameter serialization")
 def load_symengine_payload(payload: bytes):
-    """Load a symengine expression from it's serialized cereal payload."""
-    # This is a horrible hack to workaround the symengine version checking
-    # it's deserialization does. There were no changes to the serialization
-    # format between 0.11 and 0.13 but the deserializer checks that it can't
-    # load across a major or minor version boundary. This works around it
-    # by just lying about the generating version.
-    import symengine
-    from symengine.lib.symengine_wrapper import (  # pylint: disable = no-name-in-module
-        load_basic,
-    )
-
-    symengine_version = symengine.__version__.split(".")
-    major = payload[2]
-    minor = payload[3]
-    if int(symengine_version[1]) != minor:
-        if major != 0:
-            raise exceptions.QpyError(
-                "Qiskit doesn't support loading a symengine payload generated with symengine >= 1.0"
-            )
-        if minor == 9:
-            raise exceptions.QpyError(
-                "Qiskit doesn't support loading a historical QPY file with `use_symengine=True` "
-                "generated in an environment using symengine 0.9.0. If you need to load this file "
-                "you can do so with Qiskit 0.45.x or 0.46.x and re-export the QPY file using "
-                "`use_symengine=False`."
-            )
-        if minor not in (11, 13):
-            raise exceptions.QpyError(
-                f"Incompatible symengine version {major}.{minor} used to generate the QPY "
-                "payload"
-            )
-        minor_version = int(symengine_version[1])
-        if minor_version not in (11, 13):
-            raise exceptions.QpyError(
-                f"Incompatible installed symengine version {symengine.__version__} to load "
-                "this QPY payload"
-            )
-        payload = bytearray(payload)
-        payload[3] = minor_version
-        payload = bytes(payload)
-    return load_basic(payload)
+    """Symengine support has been removed."""
+    raise exceptions.QpyError("Symengine payloads are no longer supported")

--- a/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
@@ -497,14 +497,8 @@ class TemplateSubstitution:
         """
         import sympy as sym
 
-        if _optionals.HAS_SYMENGINE:
-            import symengine
-
-            # Converts Sympy expressions to Symengine ones.
-            to_native_symbolic = symengine.sympify
-        else:
-            # Our native form is sympy, so we don't need to do anything.
-            to_native_symbolic = lambda x: x
+        # Our native form is sympy, so we don't need to do anything.
+        to_native_symbolic = lambda x: x
 
         circuit_params, template_params = [], []
         # Set of all parameter names that are present in the circuits to be optimized.

--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -170,12 +170,6 @@ External Python Libraries
     `SQSnobFit <https://pypi.org/project/SQSnobFit/>`__ is a library for the "stable noisy
     optimization by branch and fit" algorithm.  It is used by the :class:`.SNOBFIT` optimizer.
 
-.. py:data:: HAS_SYMENGINE
-
-    `Symengine <https://github.com/symengine/symengine>`__ is a fast C++ backend for the
-    symbolic-manipulation library `Sympy <https://www.sympy.org/en/index.html>`__.  Qiskit uses
-    special methods from Symengine to accelerate its handling of
-    :class:`~.circuit.Parameter`\\ s if available.
 
 .. py:data:: HAS_SYMPY
 
@@ -329,7 +323,6 @@ HAS_SKQUANT = _LazyImportTester(
     install="pip install scikit-quant",
 )
 HAS_SQSNOBFIT = _LazyImportTester("SQSnobFit", install="pip install SQSnobFit")
-HAS_SYMENGINE = _LazyImportTester("symengine", install="pip install symengine<0.14")
 HAS_SYMPY = _LazyImportTester("sympy", install="pip install sympy")
 HAS_TESTTOOLS = _LazyImportTester("testtools", install="pip install testtools")
 HAS_TWEEDLEDUM = _LazyImportTester("tweedledum", install="pip install tweedledum")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,3 @@ python-dateutil>=2.8.0
 stevedore>=3.0.0
 typing-extensions
 
-# If updating the version range here, consider updating the 
-# list of symengine dependencies used in the cross-version tests
-# in 'test/qpy_compat/run_tests.sh' and 'test/qpy_compat/qpy_test_constraints.txt'
-symengine>=0.11,<0.14


### PR DESCRIPTION
## Summary
- drop symengine from install requirements
- use sympy in place of symengine
- update optional dependency helpers
- drop symengine support in QPY helpers
- add test extra with ddt dependency

## Testing
- `pytest -k test_parameter_immutability test/python/circuit/test_parameters.py -q` *(fails: ModuleNotFoundError: No module named 'ddt')*

------
https://chatgpt.com/codex/tasks/task_e_6857fff027b08325b084e830c3b6f2ce