### PR TITLE
Replace symengine alias usages

### DIFF
--- a/qiskit/circuit/parameter.py
+++ b/qiskit/circuit/parameter.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from uuid import uuid4, UUID
 
-import symengine
+import sympy
 
 from qiskit.circuit.exceptions import CircuitError
 
@@ -81,7 +81,7 @@ class Parameter(ParameterExpression):
                 allows them to be equal.  This is useful during serialization and deserialization.
         """
         self._uuid = uuid4() if uuid is None else uuid
-        symbol = symengine.Symbol(name)
+        symbol = sympy.Symbol(name)
 
         self._symbol_expr = symbol
         self._parameter_keys = frozenset((self._hash_key(),))
@@ -103,7 +103,7 @@ class Parameter(ParameterExpression):
             return value
         # This is the `super().bind` case, where we're required to return a `ParameterExpression`,
         # so we need to lift the given value to a symbolic expression.
-        return ParameterExpression({}, symengine.sympify(value))
+        return ParameterExpression({}, sympy.sympify(value))
 
     def subs(self, parameter_map: dict, allow_unknown_parameters: bool = False):
         """Substitute self with the corresponding parameter in ``parameter_map``."""

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -23,7 +23,7 @@ import numbers
 import operator
 
 import numpy
-import symengine
+import sympy
 
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.exceptions import QiskitError
@@ -162,7 +162,7 @@ class ParameterExpression:
         new_replay = self._qpy_replay.copy()
         new_replay.append(new_op)
         conjugated = ParameterExpression(
-            self._parameter_symbols, symengine.conjugate(self._symbol_expr), _qpy_replay=new_replay
+            self._parameter_symbols, sympy.conjugate(self._symbol_expr), _qpy_replay=new_replay
         )
         return conjugated
 
@@ -279,7 +279,7 @@ class ParameterExpression:
         new_parameter_symbols = {
             p: s for p, s in self._parameter_symbols.items() if p not in parameter_map
         }
-        symbol_type = symengine.Symbol
+        symbol_type = sympy.Symbol
 
         # If new_param is an expr, we'll need to construct a matching sympy expr
         # but with our sympy symbols instead of theirs.
@@ -422,7 +422,7 @@ class ParameterExpression:
 
         # Compute the gradient of the parameter expression w.r.t. param
         key = self._parameter_symbols[param]
-        expr_grad = symengine.Derivative(self._symbol_expr, key)
+        expr_grad = sympy.Derivative(self._symbol_expr, key)
 
         # generate the new dictionary of symbols
         # this needs to be done since in the derivative some symbols might disappear (e.g.
@@ -492,39 +492,39 @@ class ParameterExpression:
 
     def sin(self):
         """Sine of a ParameterExpression"""
-        return self._call(symengine.sin, op_code=_OPCode.SIN)
+        return self._call(sympy.sin, op_code=_OPCode.SIN)
 
     def cos(self):
         """Cosine of a ParameterExpression"""
-        return self._call(symengine.cos, op_code=_OPCode.COS)
+        return self._call(sympy.cos, op_code=_OPCode.COS)
 
     def tan(self):
         """Tangent of a ParameterExpression"""
-        return self._call(symengine.tan, op_code=_OPCode.TAN)
+        return self._call(sympy.tan, op_code=_OPCode.TAN)
 
     def arcsin(self):
         """Arcsin of a ParameterExpression"""
-        return self._call(symengine.asin, op_code=_OPCode.ASIN)
+        return self._call(sympy.asin, op_code=_OPCode.ASIN)
 
     def arccos(self):
         """Arccos of a ParameterExpression"""
-        return self._call(symengine.acos, op_code=_OPCode.ACOS)
+        return self._call(sympy.acos, op_code=_OPCode.ACOS)
 
     def arctan(self):
         """Arctan of a ParameterExpression"""
-        return self._call(symengine.atan, op_code=_OPCode.ATAN)
+        return self._call(sympy.atan, op_code=_OPCode.ATAN)
 
     def exp(self):
         """Exponential of a ParameterExpression"""
-        return self._call(symengine.exp, op_code=_OPCode.EXP)
+        return self._call(sympy.exp, op_code=_OPCode.EXP)
 
     def log(self):
         """Logarithm of a ParameterExpression"""
-        return self._call(symengine.log, op_code=_OPCode.LOG)
+        return self._call(sympy.log, op_code=_OPCode.LOG)
 
     def sign(self):
         """Sign of a ParameterExpression"""
-        return self._call(symengine.sign, op_code=_OPCode.SIGN)
+        return self._call(sympy.sign, op_code=_OPCode.SIGN)
 
     def __repr__(self):
         return f"{self.__class__.__name__}({str(self)})"
@@ -532,7 +532,7 @@ class ParameterExpression:
     def __str__(self):
         from sympy import sympify, sstr
 
-        if not isinstance(self._symbol_expr, symengine.Basic):
+        if not isinstance(self._symbol_expr, sympy.Basic):
             raise QiskitError("Invalid ParameterExpression")
 
         return sstr(sympify(self._symbol_expr), full_prec=False)
@@ -595,7 +595,7 @@ class ParameterExpression:
 
     def __abs__(self):
         """Absolute of a ParameterExpression"""
-        return self._call(symengine.Abs, _OPCode.ABS)
+        return self._call(sympy.Abs, _OPCode.ABS)
 
     def abs(self):
         """Absolute of a ParameterExpression"""
@@ -615,7 +615,7 @@ class ParameterExpression:
                 return False
             from sympy import sympify
 
-            if not isinstance(self._symbol_expr, symengine.Basic):
+            if not isinstance(self._symbol_expr, sympy.Basic):
                 raise QiskitError("Invalid ParameterExpression")
 
             return sympify(self._symbol_expr).equals(sympify(other._symbol_expr))

--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -11,8 +11,7 @@
 # that they have been altered from the originals.
 # pylint: disable=too-many-return-statements
 
-"""Check if number close to values of PI
-"""
+"""Check if number close to values of PI"""
 
 import numpy as np
 from qiskit.circuit.parameterexpression import ParameterExpression
@@ -49,9 +48,9 @@ def pi_check(inpt, eps=1e-9, output="text", ndigits=None):
     if isinstance(inpt, ParameterExpression):
         param_str = str(inpt)
         from sympy import sympify
-        import symengine
+        import sympy
 
-        if not isinstance(inpt._symbol_expr, symengine.Basic):
+        if not isinstance(inpt._symbol_expr, sympy.Basic):
             raise QiskitError("Invalid ParameterExpression provided")
         expr = sympify(inpt._symbol_expr)
         syms = expr.atoms()

--- a/qiskit/qpy/binary_io/value.py
+++ b/qiskit/qpy/binary_io/value.py
@@ -20,7 +20,7 @@ import struct
 import uuid
 
 import numpy as np
-import symengine
+import sympy
 
 
 from qiskit.circuit import CASE_DEFAULT, Clbit, ClassicalRegister, Duration
@@ -476,7 +476,7 @@ def _read_parameter_expression(file_obj):
     )
 
     sympy_str = file_obj.read(data.expr_size).decode(common.ENCODE)
-    expr_ = symengine.sympify(parse_sympy_repr(sympy_str))
+    expr_ = sympy.sympify(parse_sympy_repr(sympy_str))
     symbol_map = {}
     for _ in range(data.map_elements):
         elem_data = formats.PARAM_EXPR_MAP_ELEM(
@@ -516,7 +516,7 @@ def _read_parameter_expression_v3(file_obj, vectors, use_symengine):
         expr_ = common.load_symengine_payload(payload)
     else:
         sympy_str = payload.decode(common.ENCODE)
-        expr_ = symengine.sympify(parse_sympy_repr(sympy_str))
+        expr_ = sympy.sympify(parse_sympy_repr(sympy_str))
 
     symbol_map = {}
     for _ in range(data.map_elements):


### PR DESCRIPTION
## Summary
- use direct `sympy` import instead of aliasing as `symengine`
- update parameter expression helpers
- fix `pi_check` symbolic helpers
- update QPY binary handling

## Testing
- `black --check qiskit/circuit/parameter.py qiskit/circuit/parameterexpression.py qiskit/circuit/tools/pi_check.py qiskit/qpy/binary_io/value.py`

------
https://chatgpt.com/codex/tasks/task_e_68580d57d7388325a9f5edc30e843a05