### PR TITLE
Remove multiprocessing

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -20,7 +20,6 @@ import collections.abc
 import copy as _copy
 
 import itertools
-import multiprocessing
 import typing
 from collections import OrderedDict
 from typing import (
@@ -1361,11 +1360,7 @@ class QuantumCircuit:
 
     def _name_update(self) -> None:
         """update name of instance using instance number"""
-        if multiprocessing.parent_process() is None:
-            pid_name = ""
-        else:
-            pid_name = f"-{multiprocessing.current_process().pid}"
-        self.name = f"{self._base_name}-{self._cls_instances()}{pid_name}"
+        self.name = f"{self._base_name}-{self._cls_instances()}"
 
     def has_register(self, register: Register) -> bool:
         """

--- a/tools/find_stray_release_notes.py
+++ b/tools/find_stray_release_notes.py
@@ -14,7 +14,6 @@
 """Utility script to verify qiskit copyright file headers"""
 
 import argparse
-import multiprocessing
 import subprocess
 import sys
 import re
@@ -44,8 +43,7 @@ def _main():
     parser = argparse.ArgumentParser(description="Find any stray release notes.")
     _args = parser.parse_args()
     files = discover_files()
-    with multiprocessing.Pool() as pool:
-        res = pool.map(validate_path, files)
+    res = [validate_path(file) for file in files]
     failed_files = [x for x in res if x is not None]
     if len(failed_files) > 0:
         for failed_file in failed_files:

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -16,7 +16,6 @@
 """Utility script to verify qiskit copyright file headers"""
 
 import argparse
-import multiprocessing
 import os
 import sys
 import re
@@ -116,8 +115,7 @@ def _main():
     )
     args = parser.parse_args()
     files = discover_files(args.paths)
-    with multiprocessing.Pool() as pool:
-        res = pool.map(validate_header, files)
+    res = [validate_header(file) for file in files]
     failed_files = [x for x in res if x[1] is False]
     if len(failed_files) > 0:
         for failed_file in failed_files:

--- a/tools/verify_images.py
+++ b/tools/verify_images.py
@@ -15,7 +15,6 @@
 """Utility script to verify that all images have alt text"""
 
 from pathlib import Path
-import multiprocessing
 import sys
 import glob
 
@@ -81,8 +80,7 @@ def validate_image(file_path: str) -> tuple[str, list[str]]:
 def _main() -> None:
     files = glob.glob("qiskit/**/*.py", recursive=True)
 
-    with multiprocessing.Pool() as pool:
-        results = pool.map(validate_image, files)
+    results = [validate_image(file) for file in files]
 
     failed_files = {file: image_errors for file, image_errors in results if image_errors}
 


### PR DESCRIPTION
## Summary
- remove `multiprocessing` usage from QuantumCircuit and tools

## Testing
- `make test` *(fails: ImportError: cannot import name '_accelerate')*

------
https://chatgpt.com/codex/tasks/task_e_68583dbb46988325991f5d3a05ffbf89