### PR TITLE
Disable rayon features

### DIFF
--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -22,7 +22,7 @@ num-traits = "0.2"
 num-complex.workspace = true
 rustworkx-core.workspace = true
 num-bigint.workspace = true
-faer = "0.19.4"
+faer = { version = "0.19.4", default-features = false, features = ["std"] }
 itertools.workspace = true
 qiskit-circuit.workspace = true
 thiserror.workspace = true
@@ -41,7 +41,8 @@ features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec"]
 
 [dependencies.ndarray]
 workspace = true
-features = ["approx"]
+default-features = false
+features = ["std", "approx"]
 
 [dependencies.approx]
 workspace = true
@@ -49,6 +50,7 @@ features = ["num-complex"]
 
 [dependencies.hashbrown]
 workspace = true
+default-features = false
 
 [dependencies.indexmap]
 workspace = true

--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -32,10 +32,12 @@ features = ["num-complex"]
 
 [dependencies.ndarray]
 workspace = true
-features = ["approx"]
+default-features = false
+features = ["std", "approx"]
 
 [dependencies.hashbrown]
 workspace = true
+default-features = false
 
 [dependencies.indexmap]
 workspace = true

--- a/crates/qasm2/Cargo.toml
+++ b/crates/qasm2/Cargo.toml
@@ -14,6 +14,10 @@ workspace = true
 
 [dependencies]
 num-bigint.workspace = true
-hashbrown.workspace = true
+
+[dependencies.hashbrown]
+workspace = true
+default-features = false
+
 pyo3.workspace = true
 qiskit-circuit.workspace = true

--- a/crates/qasm3/Cargo.toml
+++ b/crates/qasm3/Cargo.toml
@@ -12,11 +12,15 @@ doctest = false
 [lints]
 workspace = true
 
+
 [dependencies]
 indexmap.workspace = true
-hashbrown.workspace = true
 oq3_semantics = "0.7.0"
 ahash.workspace = true
+
+[dependencies.hashbrown]
+workspace = true
+default-features = false
 
 [dependencies.pyo3]
 workspace = true


### PR DESCRIPTION
## Summary
- disable ndarray and hashbrown default features to avoid pulling in rayon
- avoid pulling `faer`'s rayon feature
- keep qasm3 dependency formatting consistent

## Testing
- `cargo check -p qiskit-qasm3`

------
https://chatgpt.com/codex/tasks/task_e_6859bdd18cd48325af3c7aa11092dba2